### PR TITLE
Remove link to Azure Notebooks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,2 @@
 # Data Science Course - Class 2
-_(This material is created for our [Data Science with Python Course](https://rmotr.com/data-science-python-course))_
-
-This project consist of a number of Jupyter Notebooks. We recommend you to set them up using [Microsoft Azure Notebooks](https://notebooks.azure.com).
+_This material is created for our [Data Science with Python Course](https://rmotr.com/data-science-python-course)_


### PR DESCRIPTION
We are using this as part of the freeCodeCamp curriculum. In the rest of the curriculum we recommend people use Google Colab. It can be confusing if people are here recommended to use Azure Notebooks. 

If you don't mind, please merge this PR to remove the line recommending Azure Notebooks.